### PR TITLE
Add swift_version to podspec

### DIFF
--- a/KeychainSwift.podspec
+++ b/KeychainSwift.podspec
@@ -19,4 +19,5 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = "10.10"
   s.watchos.deployment_target = "2.0"
   s.tvos.deployment_target = "9.0"
+  s.swift_version = "4.0"
 end


### PR DESCRIPTION
When including into Objective-C only project, there isn't set the SWIFT_VERSION build by default and has to be added manually or in post_install.